### PR TITLE
Upgrade to React 19

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -1,7 +1,6 @@
-import { Component } from 'react';
+import React, { Component } from 'react';
 
-import { Widget, addResponseMessage, setQuickButtons, toggleMsgLoader, addLinkSnippet } from '../index';
-import { addUserMessage } from '..';
+import { Widget, addResponseMessage, setQuickButtons, toggleMsgLoader, addLinkSnippet, addUserMessage } from '../index';
 
 export default class App extends Component {
   componentDidMount() {
@@ -16,7 +15,10 @@ export default class App extends Component {
     setTimeout(() => {
       toggleMsgLoader();
       if (newMessage === 'fruits') {
-        setQuickButtons([ { label: 'Apple', value: 'apple' }, { label: 'Orange', value: 'orange' }, { label: 'Pear', value: 'pear' }, { label: 'Banana', value: 'banana' } ]);
+        setQuickButtons([{label: 'Apple', value: 'apple'}, {label: 'Orange', value: 'orange'}, {
+          label: 'Pear',
+          value: 'pear'
+        }, {label: 'Banana', value: 'banana'}]);
       } else {
         addResponseMessage(newMessage);
       }

--- a/dev/main.tsx
+++ b/dev/main.tsx
@@ -1,5 +1,5 @@
-import * as ReactDOM from 'react-dom';
-
+import React, { createRoot } from 'react-dom/client';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
+        "@emoji-mart/data": "^1.2.1",
         "classnames": "^2.2.6",
         "date-fns": "^2.11.1",
-        "emoji-mart": "^3.0.1",
+        "emoji-mart": "^5.6.0",
         "markdown-it": "^8.4.1",
         "markdown-it-link-attributes": "^2.1.0",
         "markdown-it-sanitizer": "^0.4.3",
         "markdown-it-sup": "^1.0.0",
-        "react-redux": "^7.2.4",
-        "redux": "^4.1.0"
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.4",
@@ -26,17 +27,17 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-react-jsx": "^7.14.9",
         "@babel/preset-env": "^7.14.1",
-        "@babel/preset-react": "^7.14.5",
+        "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.8.3",
+        "@testing-library/react": "^16.3.0",
         "@toycode/markdown-it-class": "^1.2.3",
         "@types/classnames": "^2.2.10",
         "@types/enzyme": "^3.10.19",
         "@types/jest": "^25.1.4",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "@types/react-redux": "^7.1.7",
+        "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
+        "@types/react-redux": "^7.1.34",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
-        "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
         "autoprefixer": "^8.2.0",
         "babel-jest": "^29.7.0",
         "babel-loader": "^8.2.2",
@@ -45,7 +46,6 @@
         "clean-webpack-plugin": "^4.0.0-alpha.0",
         "css-loader": "^5.2.4",
         "css-minimizer-webpack-plugin": "^7.0.2",
-        "enzyme": "^3.11.0",
         "eslint": "^6.8.0",
         "eslint-config-wolox": "^4.0.0",
         "eslint-loader": "^3.0.3",
@@ -64,8 +64,8 @@
         "postcss-preset-env": "^6.7.0",
         "prettier": "^1.1.0",
         "prettier-eslint": "^9.0.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
         "redux-mock-store": "^1.5.4",
         "sass": "^1.90.0",
         "sass-loader": "^11.0.1",
@@ -78,10 +78,6 @@
         "webpack": "^5.101.2",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2206,6 +2202,12 @@
         "node": ">=14.17.0"
       }
     },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+      "license": "MIT"
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -3351,6 +3353,104 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -3367,6 +3467,14 @@
       "integrity": "sha512-hA4gHBK8moObkOYdWTjhy1wYcYy0MJeM3JjSKbsXHRpRMvIKhk6Jm+t3bXsSScTdz/byWqQbs8YIwVYjHp+SlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3585,6 +3693,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
       "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0"
@@ -3726,6 +3835,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -3743,36 +3853,46 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.87",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.87.tgz",
-      "integrity": "sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==",
+      "version": "19.1.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
+      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
-      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^17.0.0"
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/react-redux": {
       "version": "7.1.34",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
       "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/retry": {
@@ -3786,6 +3906,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -3843,6 +3964,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -4271,48 +4398,6 @@
         }
       }
     },
-    "node_modules/@wojtekmaj/enzyme-adapter-react-17": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.8.0.tgz",
-      "integrity": "sha512-zeUGfQRziXW7R7skzNuJyi01ZwuKCH8WiBNnTgUJwdS/CURrJwAhWsfW7nG7E30ak8Pu3ZwD9PlK9skBfAoOBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wojtekmaj/enzyme-adapter-utils": "^0.2.0",
-        "enzyme-shallow-equal": "^1.0.0",
-        "has": "^1.0.0",
-        "prop-types": "^15.7.0",
-        "react-is": "^17.0.0",
-        "react-test-renderer": "^17.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/enzyme-adapter-react-17?sponsor=1"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^17.0.0-0",
-        "react-dom": "^17.0.0-0"
-      }
-    },
-    "node_modules/@wojtekmaj/enzyme-adapter-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.2.0.tgz",
-      "integrity": "sha512-ZvZm9kZxZEKAbw+M1/Q3iDuqQndVoN8uLnxZ8bzxm7KgGTBejrGRoJAp8f1EN8eoO3iAjBNEQnTDW/H4Ekb0FQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function.prototype.name": "^1.1.0",
-        "has": "^1.0.0",
-        "object.fromentries": "^2.0.0",
-        "prop-types": "^15.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/enzyme-adapter-utils?sponsor=1"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0-0"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4583,6 +4668,17 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -4648,27 +4744,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array.prototype.filter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.4.tgz",
-      "integrity": "sha512-r+mCJ7zXgXElgR4IRC+fkvNCeoaavWBs6EdCso5Tbcf+iEMKzBU/His60lt34WEZ9vlb8wDkZvQGcVI5GwkfoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlastindex": {
@@ -6580,6 +6655,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6881,6 +6957,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6946,13 +7033,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -6985,6 +7065,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -7136,17 +7224,10 @@
       }
     },
     "node_modules/emoji-mart": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-3.0.1.tgz",
-      "integrity": "sha512-sxpmMKxqLvcscu6mFn9ITHeZNkGzIvD0BSNFE/LJESPbCA8s1jM6bCDPjWbV31xHq7JXaxgpHxLB54RCbBZSlg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0"
-      }
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7213,175 +7294,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/enzyme": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme-shallow-equal": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.7.tgz",
-      "integrity": "sha512-/um0GFqUXnpM9SvKtje+9Tjoz3f1fpBC3eXRFrNs8kpYn69JljciYP7KZTqM/YQbUY9KUjvKB4jo/q+L6WGGvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.0",
-        "object-is": "^1.1.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme/node_modules/cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/enzyme/node_modules/css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha512-dUQOBoqdR7QwV90WysXPLXG5LO7nhYBgiWVfxF80DKPF8zx1t/pUd2FYy73emg3zrjtM6dzmYgbHKfV2rxiHQA==",
-      "dev": true,
-      "license": "BSD-like",
-      "dependencies": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "node_modules/enzyme/node_modules/css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/enzyme/node_modules/dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
-      }
-    },
-    "node_modules/enzyme/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/enzyme/node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/enzyme/node_modules/domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
-      "dev": true,
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/enzyme/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/enzyme/node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/enzyme/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/enzyme/node_modules/parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/error-ex": {
@@ -7462,13 +7374,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -9189,16 +9094,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -9320,16 +9215,11 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -9382,20 +9272,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/html-element-map": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.filter": "^1.0.0",
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -10512,13 +10388,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
@@ -12790,6 +12659,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -13102,28 +12972,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -13184,18 +13032,6 @@
         "loglevel": "^1.4.1"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -13214,6 +13050,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -13531,13 +13378,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13589,36 +13429,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
-    },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13763,6 +13573,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13784,23 +13595,6 @@
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -13837,22 +13631,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -14204,13 +13982,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -17180,13 +16951,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pretty-format/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17230,23 +16994,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -17356,37 +17103,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -17437,92 +17153,55 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
-      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "react-dom": {
+        "@types/react": {
           "optional": true
         },
-        "react-native": {
+        "redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
       }
     },
     "node_modules/readable-stream": {
@@ -17567,13 +17246,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-mock-store": {
       "version": "1.5.5",
@@ -17975,16 +17651,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -18026,17 +17692,6 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
-      }
     },
     "node_modules/run-applescript": {
       "version": "7.0.0",
@@ -18295,15 +17950,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -20272,6 +19923,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iseekplant/react-chat-widget",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iseekplant/react-chat-widget",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
@@ -78,6 +78,10 @@
         "webpack": "^5.101.2",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
     "javascript"
   ],
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
     "classnames": "^2.2.6",
     "date-fns": "^2.11.1",
-    "emoji-mart": "^3.0.1",
+    "emoji-mart": "^5.6.0",
     "markdown-it": "^8.4.1",
     "markdown-it-link-attributes": "^2.1.0",
     "markdown-it-sanitizer": "^0.4.3",
     "markdown-it-sup": "^1.0.0",
-    "react-redux": "^7.2.4",
-    "redux": "^4.1.0"
+    "react-redux": "^9.2.0",
+    "redux": "^5.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -40,17 +41,17 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
     "@babel/plugin-transform-react-jsx": "^7.14.9",
     "@babel/preset-env": "^7.14.1",
-    "@babel/preset-react": "^7.14.5",
+    "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.8.3",
+    "@testing-library/react": "^16.3.0",
     "@toycode/markdown-it-class": "^1.2.3",
     "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.19",
     "@types/jest": "^25.1.4",
-    "@types/react": "^17.0.37",
-    "@types/react-dom": "^17.0.11",
-    "@types/react-redux": "^7.1.7",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "@types/react-redux": "^7.1.34",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
     "autoprefixer": "^8.2.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^8.2.2",
@@ -59,7 +60,6 @@
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "css-loader": "^5.2.4",
     "css-minimizer-webpack-plugin": "^7.0.2",
-    "enzyme": "^3.11.0",
     "eslint": "^6.8.0",
     "eslint-config-wolox": "^4.0.0",
     "eslint-loader": "^3.0.3",
@@ -78,8 +78,8 @@
     "postcss-preset-env": "^6.7.0",
     "prettier": "^1.1.0",
     "prettier-eslint": "^9.0.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "redux-mock-store": "^1.5.4",
     "sass": "^1.90.0",
     "sass-loader": "^11.0.1",
@@ -92,10 +92,6 @@
     "webpack": "^5.101.2",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2"
-  },
-  "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
   },
   "jest": {
     "verbose": true,
@@ -119,11 +115,6 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/fileMock.js",
       "\\.(css|scss)$": "<rootDir>/mocks/styleMock.js"
-    }
-  },
-  "overrides": {
-    "enzyme": {
-      "cheerio": "1.0.0-rc.3"
     }
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iseekplant/react-chat-widget",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Chat web widget for React apps",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -119,5 +119,9 @@
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
+  },
+  "peerDependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   }
 }

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/test/__snapshots__/index.test.js.snap
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Message /> should reder a <em> element 1`] = `"<p>New message with <em>Markdown</em>!</p>"`;
+exports[`<Message /> should render a <em> element 1`] = `"<p>New message with <em>Markdown</em>!</p>"`;
 
 exports[`<Message /> should render a <strong> element 1`] = `"<p>New message with <strong>Markdown</strong>!</p>"`;

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/test/index.test.js
@@ -1,30 +1,17 @@
-import { shallow, configure } from 'enzyme';
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { createNewMessage } from '../../../../../../../../../utils/messages';
 import Message from '../index';
-
-configure({ adapter: new Adapter() });
+import { render } from '@testing-library/react';
 
 describe('<Message />', () => {
-  /* eslint-disable no-underscore-dangle */
-  const createMessageComponent = message => shallow(<Message message={message} />);
-
   it('should render a <strong> element', () => {
-    const message = createNewMessage('New message with **Markdown**!');
-    const messageComponent = createMessageComponent(message);
+    const { container } = render(<Message message={createNewMessage('New message with **Markdown**!')} />);
 
-    expect(
-      messageComponent.find('.rcw-message-text').getElement().props.dangerouslySetInnerHTML.__html
-    ).toMatchSnapshot();
+    expect(container.querySelector('.rcw-message-text').innerHTML).toMatchSnapshot();
   });
 
-  it('should reder a <em> element', () => {
-    const message = createNewMessage('New message with *Markdown*!');
-    const messageComponent = createMessageComponent(message);
+  it('should render a <em> element', () => {
+    const { container } = render(<Message message={createNewMessage('New message with *Markdown*!')} />);
 
-    expect(
-      messageComponent.find('.rcw-message-text').getElement().props.dangerouslySetInnerHTML.__html
-    ).toMatchSnapshot();
+    expect(container.querySelector('.rcw-message-text').innerHTML).toMatchSnapshot();
   });
-  /* eslint-enable */
 });

--- a/src/components/Widget/components/Conversation/components/Messages/index.tsx
+++ b/src/components/Widget/components/Conversation/components/Messages/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import format from 'date-fns/format';
 
 import { scrollToBottom } from '../../../../../../utils/messages';

--- a/src/components/Widget/components/Conversation/components/Messages/index.tsx
+++ b/src/components/Widget/components/Conversation/components/Messages/index.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useRef, useState, ElementRef, ImgHTMLAttributes, MouseEvent } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 import format from 'date-fns/format';
 
 import { scrollToBottom } from '../../../../../../utils/messages';
 import { MessageTypes, Link, CustomCompMessage, GlobalState } from '../../../../../../store/types';
 import { setBadgeCount, markAllMessagesRead } from '../../../../../../store/actions';
 import { MESSAGE_SENDER } from '../../../../../../constants';
-
 import Loader from './components/Loader';
 import './styles.scss';
 
@@ -18,14 +17,16 @@ type Props = {
 
 function Messages({ profileAvatar, profileClientAvatar, showTimeStamp }: Props) {
   const dispatch = useDispatch();
+
   const { messages, typing, showChat, badgeCount } = useSelector((state: GlobalState) => ({
     messages: state.messages.messages,
     badgeCount: state.messages.badgeCount,
     typing: state.behavior.messageLoader,
-    showChat: state.behavior.showChat
-  }));
+    showChat: state.behavior.showChat,
+  }), { equalityFn: shallowEqual });
 
   const messageRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     // @ts-ignore
     scrollToBottom(messageRef.current);

--- a/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
@@ -1,40 +1,49 @@
-import { mount, configure } from 'enzyme';
-import { Provider } from 'react-redux'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-
-import { createNewMessage, createLinkSnippet, createComponentMessage } from '../../../../../../../utils/messages';
+import React from 'react';
+import { Provider } from 'react-redux';
+import {
+  createNewMessage,
+  createLinkSnippet,
+  createComponentMessage
+} from '../../../../../../../utils/messages';
 import { createMockStore } from '../../../../../../../utils/store';
-
 import Messages from '../index';
 import Message from '../components/Message';
 import Snippet from '../components/Snippet';
+import { render } from '@testing-library/react';
 
-configure({ adapter: new Adapter() });
+jest.mock('../components/Message');
+jest.mock('../components/Snippet');
 
 describe('<Messages />', () => {
-  /* eslint-disable react/prop-types */
-  const Dummy = ({ text }) => <div>{text}</div>;
-  /* eslint-enable */
+  const Dummy = jest.fn(({ text }) => <div>{text}</div>);
   const customComp = createComponentMessage(Dummy, { text: 'This is a Dummy Component!' });
   const message = createNewMessage('Response message 1');
   const linkSnippet = createLinkSnippet({ title: 'link', link: 'link' });
-  const mockStore =  createMockStore({ messages: {messages: [message, linkSnippet, customComp], badgeCount: 0 }})
+  const mockStore = createMockStore({
+    messages: { messages: [message, linkSnippet, customComp], badgeCount: 0 }
+  });
 
-  const messagesComponent = mount(
-    <Provider store={ mockStore }>
-      <Messages />
-    </Provider>
-  );
+  beforeEach(() => {
+    render(
+      <Provider store={mockStore}>
+        <Messages />
+      </Provider>
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('should render a Message component', () => {
-    expect(messagesComponent.find(Message)).toHaveLength(1);
+    expect(Message).toHaveBeenCalledTimes(1);
   });
 
   it('should render a Snippet component', () => {
-    expect(messagesComponent.find(Snippet)).toHaveLength(1);
+    expect(Snippet).toHaveBeenCalledTimes(1);
   });
 
   it('should render a custom component', () => {
-    expect(messagesComponent.find(Dummy)).toHaveLength(1);
+    expect(Dummy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Widget/components/Conversation/components/QuickButtons/index.tsx
+++ b/src/components/Widget/components/Conversation/components/QuickButtons/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import {shallowEqual, useSelector} from 'react-redux';
 
 import { GlobalState, QuickButtonTypes } from 'src/store/types';
 import { AnyFunction } from 'src/utils/types';
@@ -10,7 +10,10 @@ type Props = {
 }
 
 function QuickButtons({ onQuickButtonClicked }: Props) {
-  const buttons = useSelector((state: GlobalState) => state.quickButtons.quickButtons);
+  const buttons = useSelector(
+    (state: GlobalState) => state.quickButtons.quickButtons,
+    { equalityFn: shallowEqual },
+  );
 
   const getComponentToRender = (button: QuickButtonTypes) => {
     const ComponentToRender = button.component;

--- a/src/components/Widget/components/Conversation/components/QuickButtons/index.tsx
+++ b/src/components/Widget/components/Conversation/components/QuickButtons/index.tsx
@@ -1,4 +1,4 @@
-import {shallowEqual, useSelector} from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 import { GlobalState, QuickButtonTypes } from 'src/store/types';
 import { AnyFunction } from 'src/utils/types';

--- a/src/components/Widget/components/Conversation/components/Sender/index.tsx
+++ b/src/components/Widget/components/Conversation/components/Sender/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, forwardRef, useImperativeHandle } from 'react';
-import {shallowEqual, useSelector} from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import cn from 'classnames';
 
 import { GlobalState } from 'src/store/types';

--- a/src/components/Widget/components/Conversation/components/Sender/index.tsx
+++ b/src/components/Widget/components/Conversation/components/Sender/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, forwardRef, useImperativeHandle } from 'react';
-import { useSelector } from 'react-redux';
+import {shallowEqual, useSelector} from 'react-redux';
 import cn from 'classnames';
 
 import { GlobalState } from 'src/store/types';
@@ -23,7 +23,10 @@ type Props = {
 }
 
 function Sender({ sendMessage, placeholder, disabledInput, autofocus, onTextInputChange, buttonAlt, onPressEmoji, onChangeSize }: Props, ref) {
-  const showChat = useSelector((state: GlobalState) => state.behavior.showChat);
+  const showChat = useSelector(
+    (state: GlobalState) => state.behavior.showChat,
+    { equalityFn: shallowEqual },
+  );
   const inputRef = useRef<HTMLDivElement>(null!);
   const refContainer = useRef<HTMLDivElement>(null);
   const [enter, setEnter]= useState(false)
@@ -139,7 +142,6 @@ function Sender({ sendMessage, placeholder, disabledInput, autofocus, onTextInpu
           role="textbox"
           contentEditable={!disabledInput} 
           ref={inputRef}
-          placeholder={placeholder}
           onInput={handlerOnChange}
           onKeyPress={handlerOnKeyPress}
           onKeyUp={handlerOnKeyUp}

--- a/src/components/Widget/components/Conversation/index.tsx
+++ b/src/components/Widget/components/Conversation/index.tsx
@@ -123,7 +123,7 @@ function Conversation({
       {emojis && pickerStatus && (
           <EmojiPicker
             style={{ position: 'absolute', bottom: pickerOffset, left: '0', width: '100%' }}
-            onSelect={onSelectEmoji}
+            onEmojiSelect={onSelectEmoji}
           />
       )}
       <Sender

--- a/src/components/Widget/components/Conversation/index.tsx
+++ b/src/components/Widget/components/Conversation/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Picker } from 'emoji-mart';
 import cn from 'classnames';
 
@@ -120,10 +120,12 @@ function Conversation({
         showTimeStamp={showTimeStamp}
       />
       <QuickButtons onQuickButtonClicked={onQuickButtonClicked} />
-      {emojis && pickerStatus && (<Picker 
-        style={{ position: 'absolute', bottom: pickerOffset, left: '0', width: '100%' }}
-        onSelect={onSelectEmoji}
-      />)}
+      {emojis && pickerStatus && (
+          <EmojiPicker
+            style={{ position: 'absolute', bottom: pickerOffset, left: '0', width: '100%' }}
+            onSelect={onSelectEmoji}
+          />
+      )}
       <Sender
         ref={senderRef}
         sendMessage={handlerSendMsn}
@@ -136,6 +138,27 @@ function Conversation({
         onChangeSize={setOffset}
       />
     </div>
+  );
+}
+
+const EmojiPicker = (props) => {
+  const ref = useRef(null)
+  const instance = useRef<Picker>(null)
+
+  if (instance.current) {
+    instance.current.update(props);
+  }
+
+  useEffect(() => {
+    instance.current = new Picker({ ...props, ref });
+
+    return () => {
+      instance.current = null;
+    }
+  }, []);
+
+  return (
+      <div ref={ref}></div>
   );
 }
 

--- a/src/components/Widget/components/Conversation/style.scss
+++ b/src/components/Widget/components/Conversation/style.scss
@@ -1,7 +1,6 @@
 @import 'common';
 @import 'variables/colors';
 @import 'animation';
-@import "~emoji-mart/css/emoji-mart.css";
 
 .rcw-conversation-container {
   border-radius: 10px;

--- a/src/components/Widget/components/FullScreenPreview/index.tsx
+++ b/src/components/Widget/components/FullScreenPreview/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, ReactNode } from 'react';
 import ReactDOM from 'react-dom';
-import { useSelector, useDispatch } from 'react-redux';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 import usePreview from './usePreview';
 import usePortal from './usePortal';
 import './styles.scss';
@@ -34,7 +34,7 @@ export default function FullScreenPreview({ fullScreenMode, zoomStep }:Props) {
     width: state.preview.width,
     height: state.preview.height,
     visible: state.preview.visible
-  }));
+  }), { equalityFn: shallowEqual });
 
   useEffect(() => {
     if(src) {

--- a/src/components/Widget/components/FullScreenPreview/index.tsx
+++ b/src/components/Widget/components/FullScreenPreview/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, ReactNode } from 'react';
 import ReactDOM from 'react-dom';
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import usePreview from './usePreview';
 import usePortal from './usePortal';
 import './styles.scss';

--- a/src/components/Widget/components/Launcher/index.tsx
+++ b/src/components/Widget/components/Launcher/index.tsx
@@ -1,4 +1,4 @@
-import { useSelector, useDispatch } from 'react-redux';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 import cn from 'classnames';
 
 import Badge from './components/Badge';
@@ -25,7 +25,7 @@ function Launcher({ toggle, chatId, openImg, closeImg, openLabel, closeLabel, sh
   const { showChat, badgeCount } = useSelector((state: GlobalState) => ({
     showChat: state.behavior.showChat,
     badgeCount: state.messages.badgeCount
-  }));
+  }), { equalityFn: shallowEqual });
 
   const toggleChat = () => {
     toggle();

--- a/src/components/Widget/components/Launcher/index.tsx
+++ b/src/components/Widget/components/Launcher/index.tsx
@@ -1,4 +1,4 @@
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import cn from 'classnames';
 
 import Badge from './components/Badge';

--- a/src/components/Widget/components/Launcher/test/index.test.js
+++ b/src/components/Widget/components/Launcher/test/index.test.js
@@ -1,56 +1,64 @@
-import { configure, mount } from 'enzyme';
-import { Provider } from 'react-redux'
+import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Launcher from '../index';
 import Badge from '../components/Badge';
+import { fireEvent, render } from '@testing-library/react';
 
-configure({ adapter: new Adapter() });
 const mockStore = configureMockStore();
 
+jest.mock('../components/Badge');
+
 describe('<Launcher />', () => {
-  const createMessageComponent = ({ toggle, chatOpened, badge = 0 }) => {
-    const store = mockStore({
-      behavior: { showChat: chatOpened },
-      messages: { badgeCount: badge }
-    });
-
-    return mount(
-      <Provider store={store}>
-        <Launcher toggle={toggle} showBadge={badge > 0} />
-      </Provider>
-    );
-  };
-
   it('should call toggle prop when clicked', () => {
     const toggle = jest.fn();
     const chatOpened = false;
-    const launcherComponent = createMessageComponent({ toggle, chatOpened });
-    launcherComponent.find('.rcw-launcher').simulate('click');
+    const launcherComponent = renderLauncher({ toggle, chatOpened });
+
+    fireEvent.click(launcherComponent.container.querySelector('.rcw-launcher'));
+
     expect(toggle).toBeCalled();
   });
 
   it('should render the open-launcher image when chatOpened = false', () => {
     const toggle = jest.fn();
     const chatOpened = false;
-    const launcherComponent = createMessageComponent({ toggle, chatOpened });
-    expect(launcherComponent.find('.rcw-open-launcher')).toHaveLength(1);
+
+    const launcherComponent = renderLauncher({ toggle, chatOpened });
+
+    expect(launcherComponent.container.querySelector('.rcw-open-launcher')).not.toBeNull();
   });
 
   it('should render the close-launcher image when chatOpened = true', () => {
     const toggle = jest.fn();
     const chatOpened = true;
-    const launcherComponent = createMessageComponent({ toggle, chatOpened });
 
-    expect(launcherComponent.find('.rcw-close-launcher')).toHaveLength(1);
+    const launcherComponent = renderLauncher({ toggle, chatOpened });
+
+    expect(launcherComponent.container.querySelector('.rcw-close-launcher')).not.toBeNull();
   });
 
   it('should render Badge component when closed and new message is in', () => {
     const toggle = jest.fn();
     const chatOpened = false;
-    const badge = 1;
-    const launcherComponent = createMessageComponent({ toggle, chatOpened, badge });
+    const badgeValue = 1;
 
-    expect(launcherComponent.find(Badge).props().badge).toBe(badge);
+    renderLauncher({ toggle, chatOpened, badge: badgeValue });
+
+    const { badge } = Badge.mock.calls[0][0];
+
+    expect(badge).toBe(badgeValue);
   });
 });
+
+const renderLauncher = ({ toggle, chatOpened, badge = 0 }) => {
+  const store = mockStore({
+    behavior: { showChat: chatOpened },
+    messages: { badgeCount: badge }
+  });
+
+  return render(
+    <Provider store={store}>
+      <Launcher toggle={toggle} showBadge={badge > 0} />
+    </Provider>
+  );
+};

--- a/src/components/Widget/layout.tsx
+++ b/src/components/Widget/layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import cn from 'classnames';
 
 import { GlobalState } from 'src/store/types';

--- a/src/components/Widget/layout.tsx
+++ b/src/components/Widget/layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 import cn from 'classnames';
 
 import { GlobalState } from 'src/store/types';
@@ -74,7 +74,7 @@ function WidgetLayout({
     showChat: state.behavior.showChat,
     dissableInput: state.behavior.disabledInput,
     visible: state.preview.visible,
-  }));
+  }), { equalityFn: shallowEqual });
 
   const messageRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/components/Widget/test/index.test.js
+++ b/src/components/Widget/test/index.test.js
@@ -1,12 +1,11 @@
-import { configure, mount } from 'enzyme';
 import { Provider } from 'react-redux';
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import assetMock from '../../../../mocks/fileMock';
 import { createMockStore } from '../../../utils/store';
 import WidgetLayout from '../layout';
 import Widget from '../index';
+import { act, render } from '@testing-library/react';
 
-configure({ adapter: new Adapter() });
+jest.mock('../layout');
 
 const mockStore = createMockStore();
 
@@ -14,18 +13,30 @@ describe('<Widget />', () => {
   const profile = assetMock;
   const handleUserMessage = jest.fn();
 
-  const widgetComponent = mount(
-    <Provider store={mockStore}>
-      <Widget handleNewUserMessage={handleUserMessage} profileAvatar={profile} />
-    </Provider>
-  );
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('should render WidgetLayout', () => {
-    expect(widgetComponent.find(WidgetLayout)).toHaveLength(1);
+    render(
+      <Provider store={mockStore}>
+        <Widget handleNewUserMessage={handleUserMessage} profileAvatar={profile} />
+      </Provider>
+    );
+
+    expect(WidgetLayout).toHaveBeenCalledTimes(1);
   });
 
   it('should call the handleUserMessage callback when a new message is received', () => {
-    widgetComponent.find(WidgetLayout).prop('onSendMessage')('New message');
+    render(
+      <Provider store={mockStore}>
+        <Widget handleNewUserMessage={handleUserMessage} profileAvatar={profile} />
+      </Provider>
+    );
+
+    const { onSendMessage } = WidgetLayout.mock.calls[0][0];
+
+    act(() => onSendMessage('New message'));
 
     expect(handleUserMessage).toBeCalled();
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,34 +34,34 @@ type Props = {
   handleSubmit?: AnyFunction;
   showBadge?: boolean;
   resizable?: boolean;
-} & typeof defaultProps;
+};
 
 function ConnectedWidget({
-  title,
+  title = 'Welcome',
   titleAvatar,
-  subtitle,
-  senderPlaceHolder,
-  showCloseButton,
-  fullScreenMode,
-  autofocus,
+  subtitle = 'This is your chat subtitle',
+  senderPlaceHolder = 'Type a message...',
+  showCloseButton = true,
+  fullScreenMode = false,
+  autofocus = true,
   profileAvatar,
   profileClientAvatar,
   launcher,
   handleNewUserMessage,
   handleQuickButtonClicked,
   handleTextInputChange,
-  chatId,
+  chatId = 'rcw-chat-container',
   handleToggle,
-  launcherOpenLabel,
-  launcherCloseLabel,
-  launcherCloseImg,
-  launcherOpenImg,
-  sendButtonAlt,
-  showTimeStamp,
-  imagePreview,
-  zoomStep,
+  launcherOpenLabel = 'Open chat',
+  launcherCloseLabel = 'Close chat',
+  launcherCloseImg = '',
+  launcherOpenImg = '',
+  sendButtonAlt = 'Send',
+  showTimeStamp = true,
+  imagePreview = false,
+  zoomStep = 80,
   handleSubmit,
-  showBadge,
+  showBadge = true,
   resizable,
   emojis
 }: Props) {
@@ -99,25 +99,5 @@ function ConnectedWidget({
     </Provider>
   );
 }
-
-const defaultProps = {
-  title: 'Welcome',
-  subtitle: 'This is your chat subtitle',
-  senderPlaceHolder: 'Type a message...',
-  showCloseButton: true,
-  fullScreenMode: false,
-  autofocus: true,
-  chatId: 'rcw-chat-container',
-  launcherOpenLabel: 'Open chat',
-  launcherCloseLabel: 'Close chat',
-  launcherOpenImg: '',
-  launcherCloseImg: '',
-  sendButtonAlt: 'Send',
-  showTimeStamp: true,
-  imagePreview: false,
-  zoomStep: 80,
-  showBadge: true,
-};
-ConnectedWidget.defaultProps = defaultProps;
 
 export default ConnectedWidget;

--- a/src/store/actions/types.ts
+++ b/src/store/actions/types.ts
@@ -1,6 +1,6 @@
 import { ElementType } from 'react';
-
 import { LinkParams, FullscreenPreviewState } from '../types';
+import { UnknownAction } from 'redux';
 
 export const TOGGLE_CHAT = 'BEHAVIOR/TOGGLE_CHAT';
 export const TOGGLE_INPUT_DISABLED = 'BEHAVIOR/TOGGLE_INPUT_DISABLED';
@@ -18,72 +18,53 @@ export const SET_QUICK_BUTTONS = 'SET_QUICK_BUTTONS';
 export const OPEN_FULLSCREEN_PREVIEW = 'FULLSCREEN/OPEN_PREVIEW';
 export const CLOSE_FULLSCREEN_PREVIEW = 'FULLSCREEN/CLOSE_PREVIEW';
 
-export interface ToggleChat {
-  type: typeof TOGGLE_CHAT;
-}
+export interface ToggleChat extends UnknownAction {}
 
-export interface ToggleInputDisabled {
-  type: typeof TOGGLE_INPUT_DISABLED;
-}
+export interface ToggleInputDisabled extends UnknownAction {}
 
-export interface AddUserMessage {
-  type: typeof ADD_NEW_USER_MESSAGE;
+export interface AddUserMessage extends UnknownAction {
   text: string;
   id?: string;
 }
 
-export interface AddResponseMessage {
-  type: typeof ADD_NEW_RESPONSE_MESSAGE;
+export interface AddResponseMessage extends UnknownAction {
   text: string;
   id?: string;
 }
 
-export interface ToggleMsgLoader {
-  type: typeof TOGGLE_MESSAGE_LOADER;
-}
+export interface ToggleMsgLoader extends UnknownAction {}
 
-export interface AddLinkSnippet {
-  type: typeof ADD_NEW_LINK_SNIPPET;
+export interface AddLinkSnippet extends UnknownAction {
   link: LinkParams;
   id?: string;
 }
 
-export interface RenderCustomComponent {
-  type: typeof ADD_COMPONENT_MESSAGE;
+export interface RenderCustomComponent extends UnknownAction {
   component: ElementType;
   props: any;
   showAvatar: boolean;
   id?: string;
 }
 
-export interface DropMessages {
-  type: typeof DROP_MESSAGES;
-}
+export interface DropMessages extends UnknownAction {}
 
-export interface HideAvatar {
-  type: typeof HIDE_AVATAR;
+export interface HideAvatar extends UnknownAction {
   index: number;
 }
 
-export interface DeleteMessages {
-  type: typeof DELETE_MESSAGES;
-  count: number;
+export interface DeleteMessages extends UnknownAction {
   id?: string;
 }
 
-export interface SetQuickButtons {
-  type: typeof SET_QUICK_BUTTONS;
+export interface SetQuickButtons extends UnknownAction {
   buttons: Array<{ label: string, value: string | number }>;
 }
 
-export interface SetBadgeCount {
-  type: typeof SET_BADGE_COUNT;
+export interface SetBadgeCount extends UnknownAction {
   count: number;
 }
 
-export interface MarkAllMessagesRead {
-  type: typeof MARK_ALL_READ;
-}
+export interface MarkAllMessagesRead extends UnknownAction {}
 
 export type BehaviorActions = ToggleChat | ToggleInputDisabled | ToggleMsgLoader;
 
@@ -92,13 +73,10 @@ export type MessagesActions = AddUserMessage | AddResponseMessage | AddLinkSnipp
 
 export type QuickButtonsActions = SetQuickButtons;
 
-export interface openFullscreenPreview {
-  type: typeof OPEN_FULLSCREEN_PREVIEW;
+export interface openFullscreenPreview extends UnknownAction {
   payload: FullscreenPreviewState
 }
 
-export interface closeFullscreenPreview {
-  type: typeof CLOSE_FULLSCREEN_PREVIEW;
-}
+export interface closeFullscreenPreview extends UnknownAction {}
 
 export type FullscreenPreviewActions = openFullscreenPreview | closeFullscreenPreview;


### PR DESCRIPTION
This included replacing enzyme with react testing library.

emoji-mart/react wasn't compatible, so we introduced a thin react wrapper (which is based on the latest implementation of emoji-mart/react).

useSelector warned about an object being returned, so we updated the equalityFn to check for diff in the object, as opposed to its reference.

React redux types for useDispatch changed, so we updated the types that we pass into it.

defaultProps was dropped by React so we replaced it with plain JS default object property values