### PR TITLE
Allow passing through custom timestamp when adding system/user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,14 @@ As of v3.0, messages now have an optional ID that can be added on creation.If yo
   - params:
     - text: string (supports markdown)
     - id: string (optional)
+    - date: Date (optional)
   - Method to add a new message written as a response to a user input.
 
 - **addUserMessage**
   - params: 
     - text: string (supports markdown)
     - id: string (optional)
+    - date: Date (optional)
   - This method will add a new message written as a user. Keep in mind it will not trigger the prop handleNewUserMessage()
 
 - **addLinkSnippet**

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -8,6 +8,11 @@ export default class App extends Component {
     addLinkSnippet({ link: 'https://google.com', title: 'Google' });
     addResponseMessage('![](https://raw.githubusercontent.com/Wolox/press-kit/master/logos/logo_banner.png)');
     addResponseMessage('![vertical](https://d2sofvawe08yqg.cloudfront.net/reintroducing-react/hero2x?1556470143)');
+
+    let halfAnHourAgo = new Date();
+    halfAnHourAgo.setMinutes(halfAnHourAgo.getMinutes() - 30);
+
+    addResponseMessage(`this is a message from the half an hour ago.\n currently: ${new Date().toLocaleTimeString()}`, '1', halfAnHourAgo);
   }
 
   handleNewUserMessage = (newMessage: any) => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,11 @@ declare const Widget: ElementType;
 
 export function addUserMessage(text: string): void;
 export function addUserMessage(text: string, id: string): void;
+export function addUserMessage(text: string, id: string, date: Date): void;
 
 export function addResponseMessage(text: string): void;
 export function addResponseMessage(text: string, id: string): void;
+export function addResponseMessage(text: string, id: string, date: Date): void;
 
 export function addLinkSnippet(link: { link: string, title: string, target?: string }): void;
 export function addLinkSnippet(link: { link: string, title: string, target?: string }, id: string): void;

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/test/index.test.js
@@ -14,4 +14,15 @@ describe('<Message />', () => {
 
     expect(container.querySelector('.rcw-message-text').innerHTML).toMatchSnapshot();
   });
+
+  it('should render the timestamp when given', () => {
+    const { container } = render(
+      <Message
+        message={createNewMessage('some message', 'sender', '1', new Date('2025', '1', '1', '10', '30'))}
+        showTimeStamp={true}
+      />
+    );
+
+    expect(container.querySelector('.rcw-timestamp').innerHTML).toEqual('10:30');
+  });
 });

--- a/src/store/actions/index.ts
+++ b/src/store/actions/index.ts
@@ -15,19 +15,21 @@ export function toggleInputDisabled(): actionsTypes.ToggleInputDisabled {
   };
 }
 
-export function addUserMessage(text: string, id?: string): actionsTypes.AddUserMessage {
+export function addUserMessage(text: string, id?: string, date?: Date): actionsTypes.AddUserMessage {
   return {
     type: actionsTypes.ADD_NEW_USER_MESSAGE,
     text,
-    id
+    id,
+    date
   };
 }
 
-export function addResponseMessage(text: string, id?: string): actionsTypes.AddResponseMessage {
+export function addResponseMessage(text: string, id?: string, date?: Date): actionsTypes.AddResponseMessage {
   return {
     type: actionsTypes.ADD_NEW_RESPONSE_MESSAGE,
     text,
-    id
+    id,
+    date
   };
 }
 

--- a/src/store/actions/types.ts
+++ b/src/store/actions/types.ts
@@ -25,11 +25,13 @@ export interface ToggleInputDisabled extends UnknownAction {}
 export interface AddUserMessage extends UnknownAction {
   text: string;
   id?: string;
+  date?: Date;
 }
 
 export interface AddResponseMessage extends UnknownAction {
   text: string;
   id?: string;
+  date?: Date;
 }
 
 export interface ToggleMsgLoader extends UnknownAction {}

--- a/src/store/dispatcher.ts
+++ b/src/store/dispatcher.ts
@@ -4,12 +4,12 @@ import store from '.';
 import * as actions from './actions';
 import { LinkParams, ImageState } from './types';
 
-export function addUserMessage(text: string, id?: string) {
-  store.dispatch(actions.addUserMessage(text, id));
+export function addUserMessage(text: string, id?: string, date?: Date) {
+  store.dispatch(actions.addUserMessage(text, id, date));
 }
 
-export function addResponseMessage(text: string, id?: string) {
-  store.dispatch(actions.addResponseMessage(text, id));
+export function addResponseMessage(text: string, id?: string, date?: Date) {
+  store.dispatch(actions.addResponseMessage(text, id, date));
 }
 
 export function addLinkSnippet(link: LinkParams, id?: string) {

--- a/src/store/reducers/messagesReducer.ts
+++ b/src/store/reducers/messagesReducer.ts
@@ -22,11 +22,11 @@ const initialState = {
 };
 
 const messagesReducer = {
-  [ADD_NEW_USER_MESSAGE]: (state: MessagesState, { text, showClientAvatar, id }) =>
-    ({ ...state, messages: [...state.messages, createNewMessage(text, MESSAGE_SENDER.CLIENT, id)]}),
+  [ADD_NEW_USER_MESSAGE]: (state: MessagesState, { text, showClientAvatar, id, date }) =>
+    ({ ...state, messages: [...state.messages, createNewMessage(text, MESSAGE_SENDER.CLIENT, id, date)]}),
 
-  [ADD_NEW_RESPONSE_MESSAGE]: (state: MessagesState, { text, id }) =>
-    ({ ...state, messages: [...state.messages, createNewMessage(text, MESSAGE_SENDER.RESPONSE, id)], badgeCount: state.badgeCount + 1 }),
+  [ADD_NEW_RESPONSE_MESSAGE]: (state: MessagesState, { text, id, date }) =>
+    ({ ...state, messages: [...state.messages, createNewMessage(text, MESSAGE_SENDER.RESPONSE, id, date)], badgeCount: state.badgeCount + 1 }),
 
   [ADD_NEW_LINK_SNIPPET]: (state: MessagesState, { link, id }) =>
     ({ ...state, messages: [...state.messages, createLinkSnippet(link, id)] }),

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -12,13 +12,14 @@ export function createNewMessage(
   text: string,
   sender: string,
   id?: string,
+  date?: Date,
 ): MessageI {
   return {
     type: MESSAGES_TYPES.TEXT,
     component: Message,
     text,
     sender,
-    timestamp: new Date(),
+    timestamp: date ?? new Date(),
     showAvatar: true,
     customId: id,
     unread: sender === MESSAGE_SENDER.RESPONSE


### PR DESCRIPTION
<img width="450" height="276" alt="Screenshot 2025-08-25 at 3 26 12 pm" src="https://github.com/user-attachments/assets/52f8eede-2e55-417e-aa45-a82a683ac7e0" />
